### PR TITLE
Fix bug regarding the use of the base image

### DIFF
--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -176,13 +176,13 @@ func (p *Processor) processElasticSearchCluster(c myspec.ElasticSearchCluster) e
 		zoneDistribution := p.calculateZoneDistribution(c.Spec.DataNodeReplicas, zoneCount)
 
 		for index, count := range zoneDistribution {
-			p.k8sclient.CreateDataNodeDeployment(&count, p.baseImage, c.Spec.Zones[index], c.Spec.DataDiskSize)
+			p.k8sclient.CreateDataNodeDeployment(&count, baseImage, c.Spec.Zones[index], c.Spec.DataDiskSize)
 		}
 	} else {
 		// No zones defined, rely on current provisioning logic which may break. Other strategy is to use emptyDir?
 		// NOTE: Issue with dynamic PV provisioning (https://github.com/kubernetes/kubernetes/issues/34583)
 		p.k8sclient.CreateStorageClass("standard", c.Spec.Storage.StorageClassProvisoner, c.Spec.Storage.StorageType)
-		p.k8sclient.CreateDataNodeDeployment(func() *int32 { i := int32(c.Spec.DataNodeReplicas); return &i }(), p.baseImage, "standard", c.Spec.DataDiskSize)
+		p.k8sclient.CreateDataNodeDeployment(func() *int32 { i := int32(c.Spec.DataNodeReplicas); return &i }(), baseImage, "standard", c.Spec.DataDiskSize)
 	}
 
 	// Setup CronSchedule


### PR DESCRIPTION
Fixes #19 

Updated code so that the Elasticsearch data containers are created using the calculated base image to allow custom images to be used when specified in the cluster manifest.