### PR TITLE
Namespace watch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: all build container push clean test
 
-TAG ?= 0.0.2
+TAG ?= 0.0.3
 PREFIX ?= upmcenterprises
 
 all: container

--- a/util/k8sutil/k8sutil.go
+++ b/util/k8sutil/k8sutil.go
@@ -206,7 +206,7 @@ func (k *K8sutil) MonitorElasticSearchEvents(stopchan chan struct{}) (<-chan *my
 	events := make(chan *myspec.ElasticsearchCluster)
 	errc := make(chan error, 1)
 
-	source := cache.NewListWatchFromClient(k.TprClient, "elasticsearchclusters", api.NamespaceAll, fields.Everything())
+	source := cache.NewListWatchFromClient(k.TprClient, "elasticsearchclusters", namespace, fields.Everything())
 
 	createAddHandler := func(obj interface{}) {
 		event := obj.(*myspec.ElasticsearchCluster)


### PR DESCRIPTION
The watching of TPR was broken when removing `kubectl proxy`.  This makes sure the controller only looks at it's own namespace for deployments. A later PR needs to happen to make the controller work across any namespace. 