### PR TITLE
fix the snapshot service url

### DIFF
--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -400,10 +400,15 @@ func (k *K8sutil) CreateDataService(clusterName string) error {
 	return nil
 }
 
+// GetClientServiceName return the name of the client service
+func (k *K8sutil) GetClientServiceName(clusterName string) string {
+	return fmt.Sprintf("%s-%s", clientServiceName, clusterName)
+}
+
 // CreateClientService creates the client service
 func (k *K8sutil) CreateClientService(clusterName string, nodePort int32) error {
 
-	fullClientServiceName := clientServiceName + "-" + clusterName
+	fullClientServiceName := k.GetClientServiceName(clusterName)
 	component := "elasticsearch" + "-" + clusterName
 	// Check if service exists
 	svc, err := k.Kclient.Services(namespace).Get(fullClientServiceName)

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -133,6 +133,7 @@ func (p *Processor) refreshClusters() error {
 					cluster.Spec.Snapshot.SchedulerEnabled,
 					cluster.Spec.Snapshot.Authentication.UserName,
 					cluster.Spec.Snapshot.Authentication.Password,
+					p.k8sclient.GetClientServiceName(cluster.Metadata.Name),
 				),
 				Resources: myspec.Resources{
 					Limits: myspec.MemoryCPU{


### PR DESCRIPTION
The snapshot url was trying to reach an incorect service url.

**Error**

```
[elasticsearch-operator-1974566318-c2qnx] time="2017-07-03T11:33:10Z"
 level=error msg="Error attempting to create snapshot: Put 
https://elasticsearch:9200/_snapshot/elasticsnapshots99/snapshot_2017-07-03-11-33-10?wait_for_completion=true: 
dial tcp 100.67.80.146:9200: getsockopt: connection refused"
```