### PR TITLE
Storage Class as Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@ Following parameters are available to customize the elastic cluster:
   - bucket-name: Name of S3 bucket to dump snaptshots
   - cron-schedule: Cron task definition for intervals to do snapshots
 - [storage](https://kubernetes.io/docs/user-guide/persistent-volumes/)
-  - type: Defines the type of storage to provision based upon cloud (e.g. `gp2`)
-  - storage-class-provisioner: Defines which type of provisioner to use (e.g. `kubernetes.io/aws-ebs`)
+  - Using a provisioner
+    - type: Defines the type of storage to provision based upon cloud (e.g. `gp2`)
+    - storage-class-provisioner: Defines which type of provisioner to use (e.g. `kubernetes.io/aws-ebs`)
+  - Using an existing Storage Class (e.g. storage class for GlusterFS)
+    - storage-class: Name of an existing StorageClass object to use (zones can be [])
 - instrumentation
   - statsd-host: Sets the statsd host to send metrics to if enabled
 

--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -129,6 +129,9 @@ type Storage struct {
 
 	// StorageClassProvisoner is the storage provisioner type
 	StorageClassProvisoner string `json:"storage-class-provisioner"`
+
+	// StorageClass to use
+	StorageClass string `json:"storage-class"`
 }
 
 // Resources defines CPU / Memory restrictions on pods


### PR DESCRIPTION
### Added the possibility to use a given StorageClass

The use case is: non AWS environments like bare metal or, as in my case, other cloud provider without something similar to EBS. The ability to provide a storage class is a great more on flexibility without disturbing other configurations.

f.e. using it with GlusterFS 

```yaml
apiVersion: enterprises.upmc.com/v1
kind: ElasticsearchCluster
metadata:
  name: es-suchen
  namespace: suchen
spec:
  client-node-replicas: 1
  master-node-replicas: 1
  data-node-replicas: 3
  elastic-search-image: upmcenterprises/docker-elasticsearch-kubernetes:5.3.1_3
  zones: []
  data-volume-size: 2Gi
  java-options: "-Xms256m -Xmx256m"
  storage:
    storage-class: distributed
```

for storage class:

```yaml
apiVersion: storage.k8s.io/v1beta1
kind: StorageClass
metadata:
  name: distributed
provisioner: kubernetes.io/glusterfs
parameters:
  resturl: "http://10.100.106.28:8080"
  volumetype: none
```

generates:

```yaml
apiVersion: apps/v1beta1
kind: StatefulSet
. . .
  volumeClaimTemplates:
  - metadata:
      annotations:
        volume.beta.kubernetes.io/storage-class: distributed
      creationTimestamp: null
      labels:
        component: elasticsearch
        name: es-data-log-distributed
        role: data
      name: es-data
    spec:
      accessModes:
      - ReadWriteOnce
      resources:
        requests:
          storage: 10Gi
```