### PR TITLE
Enable http on all nodes

### DIFF
--- a/pkg/k8sutil/deployments.go
+++ b/pkg/k8sutil/deployments.go
@@ -99,7 +99,6 @@ func (k *K8sutil) CreateClientDeployment(baseImage string, replicas *int32, java
 	component := fmt.Sprintf("elasticsearch-%s", clusterName)
 	discoveryServiceNameCluster := fmt.Sprintf("%s-%s", discoveryServiceName, clusterName)
 
-	httpEnable := "true"
 	deploymentName := fmt.Sprintf("%s-%s", clientDeploymentName, clusterName)
 	isNodeMaster := "false"
 	role := "client"
@@ -175,7 +174,7 @@ func (k *K8sutil) CreateClientDeployment(baseImage string, replicas *int32, java
 									},
 									v1.EnvVar{
 										Name:  "HTTP_ENABLE",
-										Value: httpEnable,
+										Value: "true",
 									},
 									v1.EnvVar{
 										Name:  "ES_JAVA_OPTS",

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -469,7 +469,7 @@ func (k *K8sutil) CreateDataNodeDeployment(deploymentType string, replicas *int3
 									},
 									v1.EnvVar{
 										Name:  "HTTP_ENABLE",
-										Value: "false",
+										Value: "true",
 									},
 									v1.EnvVar{
 										Name:  "ES_JAVA_OPTS",
@@ -492,6 +492,11 @@ func (k *K8sutil) CreateDataNodeDeployment(deploymentType string, replicas *int3
 									v1.ContainerPort{
 										Name:          "transport",
 										ContainerPort: 9300,
+										Protocol:      v1.ProtocolTCP,
+									},
+									v1.ContainerPort{
+										Name:          "http",
+										ContainerPort: 9200,
 										Protocol:      v1.ProtocolTCP,
 									},
 								},


### PR DESCRIPTION
This enabled http on all nodes, setting up for cluster health checks from the operator. 