### PR TITLE
Fix deployment example

### DIFF
--- a/example/controller.yaml
+++ b/example/controller.yaml
@@ -71,16 +71,16 @@ spec:
         ports:
         - containerPort: 8000
           name: http
-          livenessProbe:
-            httpGet:
-              path: /live
-              port: "8000"
-            initialDelaySeconds: 10
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: "8000"
-            initialDelaySeconds: 10
-            timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: 8000
+          initialDelaySeconds: 10
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8000
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
       serviceAccount: elasticsearch-operator


### PR DESCRIPTION
Somehow indentation & values got a bit jumbled
```
error: error validating "example/controller.yaml": error validating data: [found invalid field readinessProbe for v1.ContainerPort, found invalid field livenessProbe for v1.ContainerPort]; if you choose to ignore these errors, turn validation off with --validate=false
```

```The Deployment "elasticsearch-operator" is invalid:
* spec.template.spec.containers[0].livenessProbe.httpGet.port: Invalid value: "8000": must contain at least one letter or number (a-z, 0-9)
* spec.template.spec.containers[0].readinessProbe.httpGet.port: Invalid value: "8000": must contain at least one letter or number (a-z, 0-9)
```

Thanks for the awesome project!