### PR TITLE
Pass container's memory limit/requests as environment variables

### DIFF
--- a/pkg/k8sutil/deployments.go
+++ b/pkg/k8sutil/deployments.go
@@ -163,6 +163,28 @@ func (k *K8sutil) CreateClientDeployment(baseImage string, replicas *int32, java
 										},
 									},
 									v1.EnvVar{
+										Name:  "OVERWRITE_JVM_HEAPSIZE",
+										Value: "true",
+									},
+									v1.EnvVar{
+										Name: "MY_MEM_REQUEST",
+										ValueFrom: &v1.EnvVarSource{
+											ResourceFieldRef: &v1.ResourceFieldSelector{
+												ContainerName: deploymentName,
+												Resource:      "requests.memory",
+											},
+										},
+									},
+									v1.EnvVar{
+										Name: "MY_MEM_LIMIT",
+										ValueFrom: &v1.EnvVarSource{
+											ResourceFieldRef: &v1.ResourceFieldSelector{
+												ContainerName: deploymentName,
+												Resource:      "limits.memory",
+											},
+										},
+									},
+									v1.EnvVar{
 										Name:  "CLUSTER_NAME",
 										Value: clusterName,
 									},

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -478,6 +478,28 @@ func (k *K8sutil) CreateDataNodeDeployment(deploymentType string, replicas *int3
 										Value: javaOptions,
 									},
 									v1.EnvVar{
+										Name:  "OVERWRITE_JVM_HEAPSIZE",
+										Value: "true",
+									},
+									v1.EnvVar{
+										Name: "MY_MEM_REQUEST",
+										ValueFrom: &v1.EnvVarSource{
+											ResourceFieldRef: &v1.ResourceFieldSelector{
+												ContainerName: statefulSetName,
+												Resource:      "requests.memory",
+											},
+										},
+									},
+									v1.EnvVar{
+										Name: "MY_MEM_LIMIT",
+										ValueFrom: &v1.EnvVarSource{
+											ResourceFieldRef: &v1.ResourceFieldSelector{
+												ContainerName: statefulSetName,
+												Resource:      "limits.memory",
+											},
+										},
+									},
+									v1.EnvVar{
 										Name:  "STATSD_HOST",
 										Value: statsdEndpoint,
 									},


### PR DESCRIPTION
Once https://github.com/pires/docker-elasticsearch-kubernetes/pull/51 is
merged and the operator uses an image with the updated entrypoint, then
these changes will allow a container to automatically set it's JVM heap
size based on it's memory limit/request.