### PR TITLE
Update elasticsearch and kibana to version 6.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Following parameters are available to customize the elastic cluster:
 - data-node-replicas: Number of data node replicas
 - zones: Define which zones to deploy data nodes to for high availability (_Note: Zones are evenly distributed based upon number of data-node-replicas defined_)
 - data-volume-size: Size of persistent volume to attach to data nodes
-- elastic-search-image: Override the elasticsearch image (e.g. `upmcenterprises/docker-elasticsearch-kubernetes:5.3.1`)
+- elastic-search-image: Override the elasticsearch image (e.g. `upmcenterprises/docker-elasticsearch-kubernetes:6.1.3`)
 - keep-secrets-on-delete (Boolean): Tells the operator to not delete cert secrets when a cluster is deleted
 - [snapshot](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html)
   - scheduler-enabled: If the cron scheduler should be running to enable snapshotting
@@ -65,7 +65,7 @@ If supplying your own certs, first generate them and add to a secret. Secret sho
 
 ## Base image
 
-The base image used is `upmcenterprises/docker-elasticsearch-kubernetes:5.3.1` which can be overriden by addeding to the custom cluster you create _(See: [CustomResourceDefinition](#customdesourcedefinition) above)_. 
+The base image used is `upmcenterprises/docker-elasticsearch-kubernetes:6.1.3` which can be overriden by addeding to the custom cluster you create _(See: [CustomResourceDefinition](#customdesourcedefinition) above)_. 
 
 _NOTE: If no image is specified, the default noted previously is used._
 
@@ -144,7 +144,7 @@ elasticsearch-operator  	1       	Thu Dec  7 11:49:13 2017	DEPLOYED	elasticsearc
 ```
 spec:
   kibana: 
-    image: upmcenterprises/kibana:5.3.1
+    image: docker.elastic.co/kibana/kibana-oss:6.2.1
   cerebro:
     image: upmcenterprises/cerebro:0.6.8
 ```

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -37,7 +37,7 @@ storage:
 
 kibana:
   enabled: false
-  image: upmcenterprises/kibana:5.3.1
+  image: docker.elastic.co/kibana/kibana-oss:6.2.1
 
 cerebro:
   enabled: false

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -55,7 +55,7 @@ var (
 
 func init() {
 	flag.BoolVar(&printVersion, "version", false, "Show version and quit")
-	flag.StringVar(&baseImage, "baseImage", "upmcenterprises/docker-elasticsearch-kubernetes:5.3.1", "Base image to use when spinning up the elasticsearch components.")
+	flag.StringVar(&baseImage, "baseImage", "upmcenterprises/docker-elasticsearch-kubernetes:6.1.3", "Base image to use when spinning up the elasticsearch components.")
 	flag.StringVar(&kubeCfgFile, "kubecfg-file", "", "Location of kubecfg file for access to kubernetes master service; --kube_master_url overrides the URL part of this; if neither this nor --kube_master_url are provided, defaults to service account tokens")
 	flag.StringVar(&masterHost, "masterhost", "http://127.0.0.1:8001", "Full url to k8s api server")
 	flag.Parse()

--- a/example/example-es-cluster-hostpath.yaml
+++ b/example/example-es-cluster-hostpath.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-es-cluster
 spec:
   kibana:
-    image: upmcenterprises/kibana:5.3.1
+    image: docker.elastic.co/kibana/kibana-oss:6.2.1
   cerebro:
     image: upmcenterprises/cerebro:0.6.8
   elastic-search-image: upmcenterprises/docker-elasticsearch-kubernetes:5.6.4_1

--- a/example/example-es-cluster-minikube.yaml
+++ b/example/example-es-cluster-minikube.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-es-cluster
 spec:
   kibana:
-    image: upmcenterprises/kibana:5.3.1
+    image: docker.elastic.co/kibana/kibana-oss:6.2.1
   cerebro:
    image: upmcenterprises/cerebro:0.6.8
   elastic-search-image: upmcenterprises/docker-elasticsearch-kubernetes:5.6.4_1

--- a/example/example-es-cluster-rook.yaml
+++ b/example/example-es-cluster-rook.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-es-cluster
 spec:
   kibana:
-    image: upmcenterprises/kibana:5.3.1
+    image: docker.elastic.co/kibana/kibana-oss:6.2.1
   elastic-search-image: upmcenterprises/docker-elasticsearch-kubernetes:5.6.4_1
   client-node-replicas: 3
   master-node-replicas: 2

--- a/example/example-es-cluster.yaml
+++ b/example/example-es-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-es-cluster
 spec:
   kibana:
-    image: upmcenterprises/kibana:5.3.1
+    image: docker.elastic.co/kibana/kibana-oss:6.2.1
   cerebro:
     image: upmcenterprises/cerebro:0.6.8
   elastic-search-image: upmcenterprises/docker-elasticsearch-kubernetes:5.6.4_1


### PR DESCRIPTION
Kibana image is moved to the oficial image, elasticsearch image depends on https://github.com/upmc-enterprises/docker-elasticsearch-kubernetes/pull/6