### PR TITLE
Fix PVC selection to enable update of VolumeReclaimPolicy of PV

### DIFF
--- a/pkg/apis/elasticsearchoperator/v1/cluster.go
+++ b/pkg/apis/elasticsearchoperator/v1/cluster.go
@@ -117,6 +117,8 @@ type ClusterSpec struct {
 
 	//KeepSecretsOnDelete tells the operator to not delete secrets when a cluster is destroyed
 	KeepSecretsOnDelete bool `json:"keep-secrets-on-delete"`
+
+	UseSSL bool `json:"use-ssl"`
 }
 
 // ImagePullSecrets defines credentials to pull image from private repository

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -362,7 +362,7 @@ func TemplateImagePullSecrets(ips []myspec.ImagePullSecrets) []v1.LocalObjectRef
 
 // CreateDataNodeDeployment creates the data node deployment
 func (k *K8sutil) CreateDataNodeDeployment(deploymentType string, replicas *int32, baseImage, storageClass string, dataDiskSize string, resources myspec.Resources,
-	imagePullSecrets []myspec.ImagePullSecrets, clusterName, statsdEndpoint, networkHost, namespace, javaOptions string) error {
+	imagePullSecrets []myspec.ImagePullSecrets, clusterName, statsdEndpoint, networkHost, namespace, javaOptions string, useSSL bool) error {
 
 	var deploymentName, role, isNodeMaster, isNodeData string
 
@@ -395,6 +395,10 @@ func (k *K8sutil) CreateDataNodeDeployment(deploymentType string, replicas *int3
 		requestMemory, _ := resource.ParseQuantity(resources.Requests.Memory)
 
 		logrus.Infof("StatefulSet %s not found, creating...", statefulSetName)
+		scheme := v1.URISchemeHTTP
+		if useSSL {
+			scheme = v1.URISchemeHTTPS
+		}
 		probe := &v1.Probe{
 			TimeoutSeconds:      30,
 			InitialDelaySeconds: 10,
@@ -403,7 +407,7 @@ func (k *K8sutil) CreateDataNodeDeployment(deploymentType string, replicas *int3
 				HTTPGet: &v1.HTTPGetAction{
 					Port:   intstr.FromInt(9200),
 					Path:   clusterHealthURL,
-					Scheme: v1.URISchemeHTTPS,
+					Scheme: scheme,
 				},
 			},
 		}

--- a/pkg/k8sutil/storage.go
+++ b/pkg/k8sutil/storage.go
@@ -88,7 +88,7 @@ func (k *K8sutil) DeleteStorageClasses(clusterName string) error {
 
 // UpdateVolumeReclaimPolicy updates the policy of the volume after it's created:
 // See: https://github.com/kubernetes/kubernetes/issues/38192
-func (k *K8sutil) UpdateVolumeReclaimPolicy(policy, namespace string) {
+func (k *K8sutil) UpdateVolumeReclaimPolicy(policy, namespace string, name string) {
 
 	var policyType v1.PersistentVolumeReclaimPolicy
 
@@ -101,8 +101,11 @@ func (k *K8sutil) UpdateVolumeReclaimPolicy(policy, namespace string) {
 		break
 	}
 
+	// pvc, err := k.Kclient.CoreV1().PersistentVolumeClaims(namespace).List(metav1.ListOptions{
+	// 	LabelSelector: "component=elasticsearch-example-es-cluster",
+	// })
 	pvc, err := k.Kclient.CoreV1().PersistentVolumeClaims(namespace).List(metav1.ListOptions{
-		LabelSelector: "component=elasticsearch-example-es-cluster",
+		LabelSelector: "component=elasticsearch-" + name,
 	})
 
 	if err != nil {

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -194,6 +194,7 @@ func (p *Processor) refreshClusters() error {
 					Cerebro: myspec.Cerebro{
 						Image: cluster.Spec.Cerebro.Image,
 					},
+					UseSSL: cluster.Spec.UseSSL,
 				},
 			},
 			Scheduler: snapshot.New(
@@ -288,7 +289,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 	}
 
 	if err := p.k8sclient.CreateClientDeployment(baseImage, &c.Spec.ClientNodeReplicas, c.Spec.JavaOptions,
-		c.Spec.Resources, c.Spec.ImagePullSecrets, c.ObjectMeta.Name, c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost, c.ObjectMeta.Namespace); err != nil {
+		c.Spec.Resources, c.Spec.ImagePullSecrets, c.ObjectMeta.Name, c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost, c.ObjectMeta.Namespace, c.Spec.UseSSL); err != nil {
 		logrus.Error("Error creating client deployment ", err)
 		return err
 	}
@@ -312,7 +313,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 		for index, count := range zoneDistributionMaster {
 			if err := p.k8sclient.CreateDataNodeDeployment("master", &count, baseImage, c.Spec.Zones[index], c.Spec.DataDiskSize, c.Spec.Resources,
 				c.Spec.ImagePullSecrets, c.ObjectMeta.Name, c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost,
-				c.ObjectMeta.Namespace, c.Spec.JavaOptions); err != nil {
+				c.ObjectMeta.Namespace, c.Spec.JavaOptions, c.Spec.UseSSL); err != nil {
 				logrus.Error("Error creating master node deployment ", err)
 				return err
 			}
@@ -322,7 +323,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 		for index, count := range zoneDistributionData {
 			if err := p.k8sclient.CreateDataNodeDeployment("data", &count, baseImage, c.Spec.Zones[index], c.Spec.DataDiskSize, c.Spec.Resources,
 				c.Spec.ImagePullSecrets, c.ObjectMeta.Name, c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost,
-				c.ObjectMeta.Namespace, c.Spec.JavaOptions); err != nil {
+				c.ObjectMeta.Namespace, c.Spec.JavaOptions, c.Spec.UseSSL); err != nil {
 				logrus.Error("Error creating data node deployment ", err)
 
 				return err
@@ -338,7 +339,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 		// Create Master Nodes
 		if err := p.k8sclient.CreateDataNodeDeployment("master", func() *int32 { i := int32(c.Spec.MasterNodeReplicas); return &i }(), baseImage, c.Spec.Storage.StorageClass,
 			c.Spec.DataDiskSize, c.Spec.Resources, c.Spec.ImagePullSecrets, c.ObjectMeta.Name,
-			c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost, c.ObjectMeta.Namespace, c.Spec.JavaOptions); err != nil {
+			c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost, c.ObjectMeta.Namespace, c.Spec.JavaOptions, c.Spec.UseSSL); err != nil {
 			logrus.Error("Error creating master node deployment ", err)
 
 			return err
@@ -347,7 +348,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 		// Create Data Nodes
 		if err := p.k8sclient.CreateDataNodeDeployment("data", func() *int32 { i := int32(c.Spec.DataNodeReplicas); return &i }(), baseImage, c.Spec.Storage.StorageClass,
 			c.Spec.DataDiskSize, c.Spec.Resources, c.Spec.ImagePullSecrets, c.ObjectMeta.Name,
-			c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost, c.ObjectMeta.Namespace, c.Spec.JavaOptions); err != nil {
+			c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost, c.ObjectMeta.Namespace, c.Spec.JavaOptions, c.Spec.UseSSL); err != nil {
 			logrus.Error("Error creating data node deployment ", err)
 			return err
 		}
@@ -356,7 +357,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 	// Deploy Kibana
 	if c.Spec.Kibana.Image != "" {
 
-		if err := p.k8sclient.CreateKibanaDeployment(c.Spec.Kibana.Image, c.ObjectMeta.Name, c.ObjectMeta.Namespace, c.Spec.ImagePullSecrets); err != nil {
+		if err := p.k8sclient.CreateKibanaDeployment(c.Spec.Kibana.Image, c.ObjectMeta.Name, c.ObjectMeta.Namespace, c.Spec.ImagePullSecrets, c.Spec.UseSSL); err != nil {
 			logrus.Error("Error creating kibana deployment ", err)
 			return err
 		}

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -233,8 +233,7 @@ func (p *Processor) processPodEvent(c *v1.Pod) error {
 	// Set the policy to retain
 	name := c.Labels["component"]
 	name = name[14:len(name)]
-	logrus.Println("--------> Pod=>Cluster name? : " + name + " - cluster: " + c.Labels["cluster"])
-	// clusterName := fmt.Sprintf("%s-%s", name, c.ObjectMeta.Namespace)
+
 	p.k8sclient.UpdateVolumeReclaimPolicy(p.clusters[fmt.Sprintf("%s-%s", name, c.ObjectMeta.Namespace)].ESCluster.Spec.Storage.VolumeReclaimPolicy, c.ObjectMeta.Namespace, name)
 
 	return nil

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -161,6 +161,7 @@ func (p *Processor) refreshClusters() error {
 						StorageType:            cluster.Spec.Storage.StorageType,
 						StorageClassProvisoner: cluster.Spec.Storage.StorageClassProvisoner,
 						StorageClass:           cluster.Spec.Storage.StorageClass,
+						VolumeReclaimPolicy:    cluster.Spec.Storage.VolumeReclaimPolicy,
 					},
 					Scheduler: myspec.Scheduler{
 						S3bucketName: cluster.Spec.Snapshot.BucketName,
@@ -232,8 +233,9 @@ func (p *Processor) processPodEvent(c *v1.Pod) error {
 	// Set the policy to retain
 	name := c.Labels["component"]
 	name = name[14:len(name)]
-
-	p.k8sclient.UpdateVolumeReclaimPolicy(p.clusters[fmt.Sprintf("%s-%s", name, c.ObjectMeta.Namespace)].ESCluster.Spec.Storage.VolumeReclaimPolicy, c.ObjectMeta.Namespace)
+	logrus.Println("--------> Pod=>Cluster name? : " + name + " - cluster: " + c.Labels["cluster"])
+	// clusterName := fmt.Sprintf("%s-%s", name, c.ObjectMeta.Namespace)
+	p.k8sclient.UpdateVolumeReclaimPolicy(p.clusters[fmt.Sprintf("%s-%s", name, c.ObjectMeta.Namespace)].ESCluster.Spec.Storage.VolumeReclaimPolicy, c.ObjectMeta.Namespace, name)
 
 	return nil
 }


### PR DESCRIPTION
The function was using the hardcoded example-elasticsearch cluster name