### PR TITLE
fixed kibana/cerebro deployments with use-ssl=false

### DIFF
--- a/pkg/k8sutil/deployments.go
+++ b/pkg/k8sutil/deployments.go
@@ -569,16 +569,6 @@ func (k *K8sutil) CreateCerebroDeployment(baseImage, clusterName, namespace, cer
 			// Certs volume
 			deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes,
 				v1.Volume{
-					Name: cert,
-					VolumeSource: v1.VolumeSource{
-						ConfigMap: &v1.ConfigMapVolumeSource{
-							LocalObjectReference: v1.LocalObjectReference{
-								Name: cert,
-							},
-						},
-					},
-				},
-				v1.Volume{
 					Name: fmt.Sprintf("%s-%s", secretName, clusterName),
 					VolumeSource: v1.VolumeSource{
 						Secret: &v1.SecretVolumeSource{
@@ -592,10 +582,6 @@ func (k *K8sutil) CreateCerebroDeployment(baseImage, clusterName, namespace, cer
 				v1.VolumeMount{
 					Name:      fmt.Sprintf("%s-%s", secretName, clusterName),
 					MountPath: elasticsearchCertspath,
-				},
-				v1.VolumeMount{
-					Name:      cert,
-					MountPath: "/usr/local/cerebro/cfg",
 				},
 			)
 		}

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -675,16 +675,22 @@ func (k *K8sutil) CreateDataNodeDeployment(deploymentType string, replicas *int3
 // CreateCerebroConfiguration creates Cerebro configuration
 func (k *K8sutil) CreateCerebroConfiguration(esHost string, useSSL *bool) map[string]string {
 
+	sslConfig := ""
+
+	if *useSSL {
+		sslConfig = fmt.Sprintf(`play.ws.ssl {
+	trustManager = {
+		stores = [
+		{ type = "PEM", path = "%s/cerebro.pem" },
+		{ path: %s/truststore.jks, type: "JKS" }
+		]
+	}
+}`,elasticsearchCertspath, elasticsearchCertspath)
+	}
+
 	x := map[string]string{}
 	x["application.conf"] = fmt.Sprintf(`
-play.ws.ssl {
-        trustManager = {
-                stores = [
-				{ type = "PEM", path = "%s/cerebro.pem" },
-				{ path: %s/truststore.jks, type: "JKS" }
-                ]
-        }
-}
+%s
 //play.crypto.secret = "ki:s:[[@=Ag?QIW2jMwkY:eqvrJ]JqoJyi2axj3ZvOv^/KavOT4ViJSv?6YY4[N"
 //play.http.secret.key = "ki:s:[[@=Ag?QIW2jMwkY:eqvrJ]JqoJyi2axj3ZvOv^/KavOT4ViJSv?6YY4[N"
 secret = "ki:s:[[@=Ag?QIW2jMwkY:eqvrJ]JqoJyi2axj3ZvOv^/KavOT4ViJSv?6YY4[N"
@@ -708,6 +714,6 @@ hosts = [
 	name = "%s"
 }
 ]
-		`, elasticsearchCertspath, elasticsearchCertspath, GetESURL(esHost, useSSL), esHost)
+		`, sslConfig, GetESURL(esHost, useSSL), esHost)
 	return x
 }

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -400,7 +400,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 			}
 		}
 
-		if err := p.k8sclient.CreateCerebroDeployment(c.Spec.Cerebro.Image, c.ObjectMeta.Name, c.ObjectMeta.Namespace, name, c.Spec.ImagePullSecrets); err != nil {
+		if err := p.k8sclient.CreateCerebroDeployment(c.Spec.Cerebro.Image, c.ObjectMeta.Name, c.ObjectMeta.Namespace, name, c.Spec.ImagePullSecrets, c.Spec.UseSSL); err != nil {
 			logrus.Error("Error creating cerebro deployment ", err)
 			return err
 		}


### PR DESCRIPTION
kibana and cerebro deployments fail with `use-ssl=false` since the certificates are missing.