### PR TITLE
GKE compatible example cluster

### DIFF
--- a/example/example-es-cluster-gke.yaml
+++ b/example/example-es-cluster-gke.yaml
@@ -1,0 +1,32 @@
+apiVersion: enterprises.upmc.com/v1
+kind: ElasticsearchCluster
+metadata:
+  name: example-es-cluster
+spec:
+  kibana:
+    image: docker.elastic.co/kibana/kibana-oss:6.1.3
+  cerebro:
+    image: upmcenterprises/cerebro:0.6.8
+  elastic-search-image: upmcenterprises/docker-elasticsearch-kubernetes:6.1.3_0
+  client-node-replicas: 3
+  master-node-replicas: 2
+  data-node-replicas: 3
+  network-host: 0.0.0.0
+  zones:
+  - us-east1-d
+  data-volume-size: 10Gi
+  java-options: "-Xms512m -Xmx512m"
+  snapshot:
+    scheduler-enabled: false
+    bucket-name: elasticsnapshots99
+    cron-schedule: "@every 2m"
+    image: upmcenterprises/elasticsearch-cron:0.0.3
+  storage:
+    storage-class-provisioner: kubernetes.io/gce-pd
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 500m
+    limits:
+      memory: 1024Mi
+      cpu: '1'


### PR DESCRIPTION
Should probably remove the snapshot section until this can be merged:
https://github.com/upmc-enterprises/elasticsearch-operator/pull/209