### PR TITLE
Make namespace of sysctl init daemonset configurable

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -47,10 +47,11 @@ import (
 var (
 	appVersion = "0.0.12"
 
-	printVersion bool
-	baseImage    string
-	kubeCfgFile  string
-	masterHost   string
+	printVersion           bool
+	baseImage              string
+	kubeCfgFile            string
+	masterHost             string
+	initDaemonsetNamespace string
 )
 
 func init() {
@@ -58,6 +59,7 @@ func init() {
 	flag.StringVar(&baseImage, "baseImage", "upmcenterprises/docker-elasticsearch-kubernetes:6.1.3_0", "Base image to use when spinning up the elasticsearch components.")
 	flag.StringVar(&kubeCfgFile, "kubecfg-file", "", "Location of kubecfg file for access to kubernetes master service; --kube_master_url overrides the URL part of this; if neither this nor --kube_master_url are provided, defaults to service account tokens")
 	flag.StringVar(&masterHost, "masterhost", "http://127.0.0.1:8001", "Full url to k8s api server")
+	flag.StringVar(&initDaemonsetNamespace, "initDaemonsetNamespace", "default", "Namespace to deploy the sysctl init daemonset into")
 	flag.Parse()
 }
 
@@ -75,7 +77,7 @@ func Main() int {
 	logrus.Infof("   baseImage: %s", baseImage)
 
 	// Init
-	k8sclient, err := k8sutil.New(kubeCfgFile, masterHost)
+	k8sclient, err := k8sutil.New(kubeCfgFile, masterHost, initDaemonsetNamespace)
 	if err != nil {
 		logrus.Error("Could not init k8sclient! ", err)
 		return 1

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -71,7 +71,7 @@ func (c *Controller) init() error {
 		return err
 	}
 
-	err = c.k8sclient.CreateNodeInitDaemonset("default")
+	err = c.k8sclient.CreateNodeInitDaemonset()
 
 	if err != nil {
 		return err

--- a/pkg/k8sutil/daemonsets.go
+++ b/pkg/k8sutil/daemonsets.go
@@ -37,9 +37,9 @@ const (
 )
 
 // CreateNodeInitDaemonset creates the node init daemonset
-func (k *K8sutil) CreateNodeInitDaemonset(namespace string) error {
+func (k *K8sutil) CreateNodeInitDaemonset() error {
 
-	ds, err := k.Kclient.ExtensionsV1beta1().DaemonSets(namespace).Get(esOperatorSysctlName, metav1.GetOptions{})
+	ds, err := k.Kclient.ExtensionsV1beta1().DaemonSets(k.InitDaemonsetNamespace).Get(esOperatorSysctlName, metav1.GetOptions{})
 
 	if err != nil && len(ds.Name) == 0 {
 
@@ -54,7 +54,7 @@ func (k *K8sutil) CreateNodeInitDaemonset(namespace string) error {
 				Labels: map[string]string{
 					"k8s-app": "elasticsearch-operator",
 				},
-				Namespace: namespace,
+				Namespace: k.InitDaemonsetNamespace,
 			},
 			Spec: v1beta1.DaemonSetSpec{
 				Template: v1.PodTemplateSpec{
@@ -94,7 +94,7 @@ func (k *K8sutil) CreateNodeInitDaemonset(namespace string) error {
 			},
 		}
 
-		_, err = k.Kclient.ExtensionsV1beta1().DaemonSets(namespace).Create(daemonset)
+		_, err = k.Kclient.ExtensionsV1beta1().DaemonSets(k.InitDaemonsetNamespace).Create(daemonset)
 
 	} else {
 		logrus.Infof("Daemonset %s already exist, skipping creation ...", ds)

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -78,16 +78,17 @@ var (
 
 // K8sutil defines the kube object
 type K8sutil struct {
-	Config     *rest.Config
-	CrdClient  genclient.Interface
-	Kclient    kubernetes.Interface
-	KubeExt    apiextensionsclient.Interface
-	K8sVersion []int
-	MasterHost string
+	Config                 *rest.Config
+	CrdClient              genclient.Interface
+	Kclient                kubernetes.Interface
+	KubeExt                apiextensionsclient.Interface
+	K8sVersion             []int
+	MasterHost             string
+	InitDaemonsetNamespace string
 }
 
 // New creates a new instance of k8sutil
-func New(kubeCfgFile, masterHost string) (*K8sutil, error) {
+func New(kubeCfgFile, masterHost, initDaemonsetNamespace string) (*K8sutil, error) {
 
 	crdClient, kubeClient, kubeExt, k8sVersion, err := newKubeClient(kubeCfgFile)
 
@@ -96,11 +97,12 @@ func New(kubeCfgFile, masterHost string) (*K8sutil, error) {
 	}
 
 	k := &K8sutil{
-		Kclient:    kubeClient,
-		MasterHost: masterHost,
-		K8sVersion: k8sVersion,
-		CrdClient:  crdClient,
-		KubeExt:    kubeExt,
+		Kclient:                kubeClient,
+		MasterHost:             masterHost,
+		K8sVersion:             k8sVersion,
+		CrdClient:              crdClient,
+		KubeExt:                kubeExt,
+		InitDaemonsetNamespace: initDaemonsetNamespace,
 	}
 
 	return k, nil
@@ -685,7 +687,7 @@ func (k *K8sutil) CreateCerebroConfiguration(esHost string, useSSL *bool) map[st
 		{ path: %s/truststore.jks, type: "JKS" }
 		]
 	}
-}`,elasticsearchCertspath, elasticsearchCertspath)
+}`, elasticsearchCertspath, elasticsearchCertspath)
 	}
 
 	x := map[string]string{}


### PR DESCRIPTION
This PR addresses #219 by adding a command line flag specifying the namespace that the sysctl init daemonset should be deployed into. The default value for the flag is the default namespace which matches the current behavior. Users that want to deploy into a different namespace can do so by passing the namespace as an argument to operator.