### PR TITLE
Added S3 user credentials functionality to Snapshots

### DIFF
--- a/pkg/apis/elasticsearchoperator/v1/cluster.go
+++ b/pkg/apis/elasticsearchoperator/v1/cluster.go
@@ -152,8 +152,6 @@ type Snapshot struct {
 	// Defines the image to run cronjobs
 	Image string `json:"image"`
 
-	UseRepoAuth bool `json:"repo-auth"`
-
 	RepoRegion string `json:"repo-region"`
 
 	RepoAuthentication RepoAuthentication `json:"repo-authentication"`
@@ -238,7 +236,6 @@ type Scheduler struct {
 	Namespace    string
 	ClusterName  string
 	Image        string
-	UseRepoAuth  bool
 	UseSSL       bool
 }
 

--- a/pkg/apis/elasticsearchoperator/v1/cluster.go
+++ b/pkg/apis/elasticsearchoperator/v1/cluster.go
@@ -151,6 +151,17 @@ type Snapshot struct {
 
 	// Defines the image to run cronjobs
 	Image string `json:"image"`
+
+	UseRepoAuth bool `json:"repo-auth"`
+
+	RepoRegion string `json:"repo-region"`
+
+	RepoAuthentication RepoAuthentication `json:"repo-authentication"`
+}
+
+type RepoAuthentication struct {
+	RepoAccessKey string `json:"access-key"`
+	RepoSecretKey string `json:"secret-key"`
 }
 
 // Authentication defines credentials for snapshot requests
@@ -221,11 +232,19 @@ type Scheduler struct {
 	CronSchedule string
 	Enabled      bool
 	Auth         SchedulerAuthentication
+	RepoAuth     RepoSchedulerAuthentication
+	RepoRegion   string
 	ElasticURL   string
 	Namespace    string
 	ClusterName  string
 	Image        string
+	UseRepoAuth  bool
 	UseSSL       bool
+}
+
+type RepoSchedulerAuthentication struct {
+	RepoAccessKey string
+	RepoSecretKey string
 }
 
 // SchedulerAuthentication stores credentials used to authenticate against snapshot endpoint

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -167,6 +167,7 @@ func (p *Processor) refreshClusters() error {
 						RepoType:         cluster.Spec.Snapshot.RepoType,
 						BucketName:       cluster.Spec.Snapshot.BucketName,
 						CronSchedule:     cluster.Spec.Snapshot.CronSchedule,
+						RepoRegion:       cluster.Spec.Snapshot.RepoRegion,
 					},
 					Storage: myspec.Storage{
 						StorageType:            cluster.Spec.Storage.StorageType,
@@ -183,6 +184,12 @@ func (p *Processor) refreshClusters() error {
 							UserName: cluster.Spec.Snapshot.Authentication.UserName,
 							Password: cluster.Spec.Snapshot.Authentication.Password,
 						},
+						UseRepoAuth: cluster.Spec.Snapshot.UseRepoAuth,
+						RepoAuth: myspec.RepoSchedulerAuthentication{
+							RepoAccessKey: cluster.Spec.Snapshot.RepoAuthentication.RepoAccessKey,
+							RepoSecretKey: cluster.Spec.Snapshot.RepoAuthentication.RepoSecretKey,
+						},
+						RepoRegion:  cluster.Spec.Snapshot.RepoRegion,
 						UseSSL:      useSSL,
 						ElasticURL:  k8sutil.GetESURL(p.k8sclient.GetClientServiceNameFullDNS(cluster.ObjectMeta.Name, cluster.ObjectMeta.Namespace), cluster.Spec.UseSSL),
 						ClusterName: cluster.ObjectMeta.Name,
@@ -218,6 +225,7 @@ func (p *Processor) refreshClusters() error {
 				cluster.Spec.Snapshot.BucketName,
 				cluster.Spec.Snapshot.CronSchedule,
 				cluster.Spec.Snapshot.SchedulerEnabled,
+				cluster.Spec.Snapshot.UseRepoAuth,
 				useSSL,
 				cluster.Spec.Snapshot.Authentication.UserName,
 				cluster.Spec.Snapshot.Authentication.Password,
@@ -225,6 +233,9 @@ func (p *Processor) refreshClusters() error {
 				p.k8sclient.GetClientServiceNameFullDNS(cluster.ObjectMeta.Name, cluster.ObjectMeta.Namespace),
 				cluster.ObjectMeta.Name,
 				cluster.ObjectMeta.Namespace,
+				cluster.Spec.Snapshot.RepoAuthentication.RepoAccessKey,
+				cluster.Spec.Snapshot.RepoAuthentication.RepoSecretKey,
+				cluster.Spec.Snapshot.RepoRegion,
 				p.k8sclient.Kclient,
 			),
 		}

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -184,7 +184,6 @@ func (p *Processor) refreshClusters() error {
 							UserName: cluster.Spec.Snapshot.Authentication.UserName,
 							Password: cluster.Spec.Snapshot.Authentication.Password,
 						},
-						UseRepoAuth: cluster.Spec.Snapshot.UseRepoAuth,
 						RepoAuth: myspec.RepoSchedulerAuthentication{
 							RepoAccessKey: cluster.Spec.Snapshot.RepoAuthentication.RepoAccessKey,
 							RepoSecretKey: cluster.Spec.Snapshot.RepoAuthentication.RepoSecretKey,
@@ -225,7 +224,6 @@ func (p *Processor) refreshClusters() error {
 				cluster.Spec.Snapshot.BucketName,
 				cluster.Spec.Snapshot.CronSchedule,
 				cluster.Spec.Snapshot.SchedulerEnabled,
-				cluster.Spec.Snapshot.UseRepoAuth,
 				useSSL,
 				cluster.Spec.Snapshot.Authentication.UserName,
 				cluster.Spec.Snapshot.Authentication.Password,

--- a/pkg/snapshot/scheduler.go
+++ b/pkg/snapshot/scheduler.go
@@ -53,7 +53,7 @@ type Scheduler struct {
 }
 
 // New creates an instance of Scheduler
-func New(repoType, bucketName, cronSchedule string, enabled, useRepoAuth, useSSL bool, userName, password, image,
+func New(repoType, bucketName, cronSchedule string, enabled, useSSL bool, userName, password, image,
 	elasticURL, clusterName, namespace, repoAccessKey, repoSecretKey, repoRegion string, kc kubernetes.Interface) *Scheduler {
 
 	if repoType == "" {
@@ -75,7 +75,6 @@ func New(repoType, bucketName, cronSchedule string, enabled, useRepoAuth, useSSL
 				UserName: userName,
 				Password: password,
 			},
-			UseRepoAuth: useRepoAuth,
 			RepoAuth: enterprisesv1.RepoSchedulerAuthentication{
 				RepoAccessKey: repoAccessKey,
 				RepoSecretKey: repoSecretKey,
@@ -233,7 +232,6 @@ func (s *Scheduler) CreateCronJob(namespace, clusterName, action, cronSchedule s
 											fmt.Sprintf("--repo-auth-access-key=%s", s.CRD.RepoAuth.RepoAccessKey),
 											fmt.Sprintf("--repo-auth-secret-key=%s", s.CRD.RepoAuth.RepoSecretKey),
 											fmt.Sprintf("--repo-region=%s", s.CRD.RepoRegion),
-											fmt.Sprintf("--use-repo-auth=%t", s.CRD.UseRepoAuth),
 											fmt.Sprintf("--use-ssl=%t", s.CRD.UseSSL),
 										},
 									},

--- a/pkg/snapshot/scheduler.go
+++ b/pkg/snapshot/scheduler.go
@@ -53,8 +53,8 @@ type Scheduler struct {
 }
 
 // New creates an instance of Scheduler
-func New(repoType, bucketName, cronSchedule string, enabled, useSSL bool, userName, password, image,
-	elasticURL, clusterName, namespace string, kc kubernetes.Interface) *Scheduler {
+func New(repoType, bucketName, cronSchedule string, enabled, useRepoAuth, useSSL bool, userName, password, image,
+	elasticURL, clusterName, namespace, repoAccessKey, repoSecretKey, repoRegion string, kc kubernetes.Interface) *Scheduler {
 
 	if repoType == "" {
 		repoType = "s3"
@@ -75,6 +75,12 @@ func New(repoType, bucketName, cronSchedule string, enabled, useSSL bool, userNa
 				UserName: userName,
 				Password: password,
 			},
+			UseRepoAuth: useRepoAuth,
+			RepoAuth: enterprisesv1.RepoSchedulerAuthentication{
+				RepoAccessKey: repoAccessKey,
+				RepoSecretKey: repoSecretKey,
+			},
+			RepoRegion:  repoRegion,
 			UseSSL:      useSSL,
 			Namespace:   namespace,
 			ClusterName: clusterName,
@@ -224,6 +230,10 @@ func (s *Scheduler) CreateCronJob(namespace, clusterName, action, cronSchedule s
 											fmt.Sprintf("--elastic-url=%s", s.CRD.ElasticURL),
 											fmt.Sprintf("--auth-username=%s", s.CRD.Auth.UserName),
 											fmt.Sprintf("--auth-password=%s", s.CRD.Auth.Password),
+											fmt.Sprintf("--repo-auth-access-key=%s", s.CRD.RepoAuth.RepoAccessKey),
+											fmt.Sprintf("--repo-auth-secret-key=%s", s.CRD.RepoAuth.RepoSecretKey),
+											fmt.Sprintf("--repo-region=%s", s.CRD.RepoRegion),
+											fmt.Sprintf("--use-repo-auth=%t", s.CRD.UseRepoAuth),
 											fmt.Sprintf("--use-ssl=%t", s.CRD.UseSSL),
 										},
 									},


### PR DESCRIPTION
This PR should solve [this issue](https://github.com/upmc-enterprises/elasticsearch-cron/issues/7) on es-cron to integrate option for S3 user credentials based backup for Snapshot. The bool flag ```--use-repo-auth``` will enable/disable this functionality (default: ```false```) as per user input. 
[Accompanying PR](https://github.com/upmc-enterprises/elasticsearch-cron/pull/8) in es-cron has been filed. The go tests for ```processer.go``` are passing.