### PR TITLE
Add serviceAcccountName option for each service

### DIFF
--- a/pkg/apis/elasticsearchoperator/v1/cluster.go
+++ b/pkg/apis/elasticsearchoperator/v1/cluster.go
@@ -120,6 +120,9 @@ type ClusterSpec struct {
 
 	// Use SSL for clients connections
 	UseSSL *bool `json:"use-ssl,omitempty"`
+
+	// serviceAccount to use when running nodes
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 // ImagePullSecrets defines credentials to pull image from private repository
@@ -196,6 +199,9 @@ type Instrumentation struct {
 type Kibana struct {
 	// Defines the image to use for deploying kibana
 	Image string `json:"image"`
+
+	// serviceAccount to use when running kibana
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 // Cerebro properties if wanting operator to deploy for user
@@ -203,6 +209,9 @@ type Cerebro struct {
 	// Defines the image to use for deploying Cerebro
 	Image         string `json:"image"`
 	Configuration string `json:"configuration"`
+
+	// serviceAccount to use when running cerebro
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 // Scheduler stores info about how to snapshot the cluster

--- a/pkg/k8sutil/deployments.go
+++ b/pkg/k8sutil/deployments.go
@@ -96,7 +96,7 @@ func (k *K8sutil) DeleteDeployment(clusterName, namespace, deploymentType string
 
 // CreateClientDeployment creates the client deployment
 func (k *K8sutil) CreateClientDeployment(baseImage string, replicas *int32, javaOptions string,
-	resources myspec.Resources, imagePullSecrets []myspec.ImagePullSecrets, clusterName, statsdEndpoint, networkHost, namespace string, useSSL *bool) error {
+	resources myspec.Resources, imagePullSecrets []myspec.ImagePullSecrets, serviceAccountName, clusterName, statsdEndpoint, networkHost, namespace string, useSSL *bool) error {
 
 	component := fmt.Sprintf("elasticsearch-%s", clusterName)
 	discoveryServiceNameCluster := fmt.Sprintf("%s-%s", discoveryServiceName, clusterName)
@@ -313,6 +313,10 @@ func (k *K8sutil) CreateClientDeployment(baseImage string, replicas *int32, java
 			deployment.Spec.Template.Spec.Volumes = volumes
 		}
 
+		if serviceAccountName != "" {
+			deployment.Spec.Template.Spec.ServiceAccountName = serviceAccountName
+		}
+
 		_, err := k.Kclient.AppsV1beta1().Deployments(namespace).Create(deployment)
 
 		if err != nil {
@@ -340,7 +344,7 @@ func (k *K8sutil) CreateClientDeployment(baseImage string, replicas *int32, java
 }
 
 // CreateKibanaDeployment creates a deployment of Kibana
-func (k *K8sutil) CreateKibanaDeployment(baseImage, clusterName, namespace string, imagePullSecrets []myspec.ImagePullSecrets, useSSL *bool) error {
+func (k *K8sutil) CreateKibanaDeployment(baseImage, clusterName, namespace string, imagePullSecrets []myspec.ImagePullSecrets, serviceAccountName string, useSSL *bool) error {
 
 	replicaCount := int32(1)
 
@@ -462,6 +466,10 @@ func (k *K8sutil) CreateKibanaDeployment(baseImage, clusterName, namespace strin
 			})
 		}
 
+		if serviceAccountName != "" {
+			deployment.Spec.Template.Spec.ServiceAccountName = serviceAccountName
+		}
+
 		_, err := k.Kclient.AppsV1beta1().Deployments(namespace).Create(deployment)
 
 		if err != nil {
@@ -479,7 +487,7 @@ func (k *K8sutil) CreateKibanaDeployment(baseImage, clusterName, namespace strin
 }
 
 // CreateCerebroDeployment creates a deployment of Cerebro
-func (k *K8sutil) CreateCerebroDeployment(baseImage, clusterName, namespace, cert string, imagePullSecrets []myspec.ImagePullSecrets, useSSL *bool) error {
+func (k *K8sutil) CreateCerebroDeployment(baseImage, clusterName, namespace, cert string, imagePullSecrets []myspec.ImagePullSecrets, serviceAccountName string, useSSL *bool) error {
 	replicaCount := int32(1)
 	component := fmt.Sprintf("elasticsearch-%s", clusterName)
 	deploymentName := fmt.Sprintf("%s-%s", cerebroDeploymentName, clusterName)
@@ -584,6 +592,10 @@ func (k *K8sutil) CreateCerebroDeployment(baseImage, clusterName, namespace, cer
 					MountPath: elasticsearchCertspath,
 				},
 			)
+		}
+
+		if serviceAccountName != "" {
+			deployment.Spec.Template.Spec.ServiceAccountName = serviceAccountName
 		}
 
 		if _, err := k.Kclient.AppsV1beta1().Deployments(namespace).Create(deployment); err != nil {

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -387,7 +387,7 @@ func processDeploymentType(deploymentType string, clusterName string) (string, s
 	return deploymentName, role, isNodeMaster, isNodeData
 }
 
-func buildStatefulSet(statefulSetName, clusterName, deploymentType, baseImage, storageClass, dataDiskSize, javaOptions,
+func buildStatefulSet(statefulSetName, clusterName, deploymentType, baseImage, storageClass, dataDiskSize, javaOptions, serviceAccountName,
 	statsdEndpoint, networkHost string, replicas *int32, useSSL *bool, resources myspec.Resources, imagePullSecrets []myspec.ImagePullSecrets) *apps.StatefulSet {
 
 	_, role, isNodeMaster, isNodeData := processDeploymentType(deploymentType, clusterName)
@@ -619,6 +619,10 @@ func buildStatefulSet(statefulSetName, clusterName, deploymentType, baseImage, s
 			})
 	}
 
+	if serviceAccountName != "" {
+		statefulSet.Spec.Template.Spec.ServiceAccountName = serviceAccountName
+	}
+
 	if storageClass != "default" {
 		statefulSet.Spec.VolumeClaimTemplates[0].Annotations = map[string]string{
 			"volume.beta.kubernetes.io/storage-class": storageClass,
@@ -630,7 +634,7 @@ func buildStatefulSet(statefulSetName, clusterName, deploymentType, baseImage, s
 
 // CreateDataNodeDeployment creates the data node deployment
 func (k *K8sutil) CreateDataNodeDeployment(deploymentType string, replicas *int32, baseImage, storageClass string, dataDiskSize string, resources myspec.Resources,
-	imagePullSecrets []myspec.ImagePullSecrets, clusterName, statsdEndpoint, networkHost, namespace, javaOptions string, useSSL *bool) error {
+	imagePullSecrets []myspec.ImagePullSecrets, serviceAccountName, clusterName, statsdEndpoint, networkHost, namespace, javaOptions string, useSSL *bool) error {
 
 	deploymentName, _, _, _ := processDeploymentType(deploymentType, clusterName)
 
@@ -643,7 +647,7 @@ func (k *K8sutil) CreateDataNodeDeployment(deploymentType string, replicas *int3
 
 		logrus.Infof("StatefulSet %s not found, creating...", statefulSetName)
 
-		statefulSet := buildStatefulSet(statefulSetName, clusterName, deploymentType, baseImage, storageClass, dataDiskSize, javaOptions,
+		statefulSet := buildStatefulSet(statefulSetName, clusterName, deploymentType, baseImage, storageClass, dataDiskSize, javaOptions, serviceAccountName,
 			statsdEndpoint, networkHost, replicas, useSSL, resources, imagePullSecrets)
 
 		if _, err := k.Kclient.AppsV1beta2().StatefulSets(namespace).Create(statefulSet); err != nil {
@@ -685,7 +689,7 @@ func (k *K8sutil) CreateCerebroConfiguration(esHost string, useSSL *bool) map[st
 		{ path: %s/truststore.jks, type: "JKS" }
 		]
 	}
-}`,elasticsearchCertspath, elasticsearchCertspath)
+}`, elasticsearchCertspath, elasticsearchCertspath)
 	}
 
 	x := map[string]string{}

--- a/pkg/k8sutil/k8sutil_test.go
+++ b/pkg/k8sutil/k8sutil_test.go
@@ -40,7 +40,7 @@ func TestSSLCertConfig(t *testing.T) {
 	clusterName := "test"
 	useSSL := false
 	statefulSet := buildStatefulSet("test", clusterName, "master", "foo/image", "test", "1G", "",
-		"", "", nil, &useSSL, resources, nil)
+		"", "", "", nil, &useSSL, resources, nil)
 
 	for _, volume := range statefulSet.Spec.Template.Spec.Volumes {
 		if volume.Name == fmt.Sprintf("%s-%s", secretName, clusterName) {
@@ -50,7 +50,7 @@ func TestSSLCertConfig(t *testing.T) {
 
 	useSSL = true
 	statefulSet = buildStatefulSet("test", clusterName, "master", "foo/image", "test", "1G", "",
-		"", "", nil, &useSSL, resources, nil)
+		"", "", "", nil, &useSSL, resources, nil)
 
 	found := false
 	for _, volume := range statefulSet.Spec.Template.Spec.Volumes {


### PR DESCRIPTION
This PR allows each service to have an optional serviceAccountName. Helpful when setting up PodSecurityPolcies and granting permissions around.

Allows the user to set an optional serviceAcccountName for any of the
services. Elasticsearch, Kibana and Cerebro, defaults to none if not
set.