### PR TITLE
The service account needs to be in the operator namespace 

### DIFF
--- a/example/controller.yaml
+++ b/example/controller.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: elasticsearch-operator
+  namespace: operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole


### PR DESCRIPTION
The service account needs to be in the operator namespace to match the rest of the examples