### PR TITLE
Adjust minimum master nodes dynamically

### DIFF
--- a/pkg/elasticsearchutil/elasticsearchutil.go
+++ b/pkg/elasticsearchutil/elasticsearchutil.go
@@ -1,0 +1,47 @@
+package elasticsearchutil
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// MinMasterNodes calculates the minium number of master nodes needed to ensure that the cluster
+// does not get into a split-brain state.
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/discovery-settings.html
+func MinMasterNodes(replicas int) int {
+	return (replicas / 2) + 1
+}
+
+// UpdateDiscoveryMinMasterNodes sets the 'discovery.zen.minimum_master_nodes' setting in elasticsearch
+// to the given minimum of master nodes.
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-update-settings.html
+func UpdateDiscoveryMinMasterNodes(esHost string, minMasterNodes int) error {
+	var jsonStr = generateMinMasterNodesPayload(minMasterNodes)
+	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/_cluster/settings", esHost), bytes.NewBuffer(jsonStr))
+	req.Header.Set("Content-Type", "application/json")
+	logrus.Debugf("request to ES: %v", req)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf(string(b))
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+func generateMinMasterNodesPayload(minMasterNodes int) []byte {
+	json := fmt.Sprintf(`{"transient": {"discovery.zen.minimum_master_nodes": %d}}`, minMasterNodes)
+	return []byte(json)
+}

--- a/pkg/elasticsearchutil/elasticsearchutil_test.go
+++ b/pkg/elasticsearchutil/elasticsearchutil_test.go
@@ -1,0 +1,28 @@
+package elasticsearchutil
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestMinMasterNodes(t *testing.T) {
+	for _, v := range []struct {
+		replicas int
+		expected int
+	}{
+		{0, 1},
+		{1, 1},
+		{2, 2},
+		{3, 2},
+		{4, 3},
+		{5, 3},
+	} {
+
+		minMasterNodes := MinMasterNodes(v.replicas)
+
+		if minMasterNodes != v.expected {
+			t.Errorf(fmt.Sprintf("Expected %d, got %d", v.expected, minMasterNodes))
+		}
+
+	}
+}

--- a/pkg/k8sutil/pod.go
+++ b/pkg/k8sutil/pod.go
@@ -1,0 +1,15 @@
+package k8sutil
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetMasterNodes returns all master node pods
+func (k *K8sutil) GetMasterNodes(namespace string, name string) (*v1.PodList, error) {
+	return k.Kclient.CoreV1().Pods(namespace).List(metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("component=elasticsearch-%s,role=master", name),
+	})
+}


### PR DESCRIPTION
This PR solves issue #105

We implemented scale up and scale down of master elasticsearch master nodes. 
**Scale up**:
We react on updated master pods. As soon as they are ready the `discovery.zen.minimum_master_nodes` setting is increased to `number_of_ready_master_pods / 2 + 1`.

**Scale down**:
Scale down is detected by a watch on the CRD elasticseach events, which reduce the number of master nodes. Reacting to scale down is critical because without adapting the `discovery.zen.minimum_master_nodes` setting, the quorum could be lost without the option to regain it.