### PR TITLE
Point healthcheck to TCP port 9300 so masters can reach quorum in order for sgadmin to initialize

### DIFF
--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -84,7 +84,7 @@ type K8sutil struct {
 	KubeExt                apiextensionsclient.Interface
 	K8sVersion             []int
 	MasterHost             string
-	EnableInitDaemonset	   bool
+	EnableInitDaemonset    bool
 	InitDaemonsetNamespace string
 	BusyboxImage           string
 }
@@ -401,10 +401,8 @@ func buildStatefulSet(statefulSetName, clusterName, deploymentType, baseImage, s
 	volumeSize, _ := resource.ParseQuantity(dataDiskSize)
 
 	enableSSL := "true"
-	scheme := v1.URISchemeHTTPS
 	if useSSL != nil && !*useSSL {
 		enableSSL = "false"
-		scheme = v1.URISchemeHTTP
 	}
 
 	// Parse CPU / Memory
@@ -418,10 +416,8 @@ func buildStatefulSet(statefulSetName, clusterName, deploymentType, baseImage, s
 		InitialDelaySeconds: 10,
 		FailureThreshold:    15,
 		Handler: v1.Handler{
-			HTTPGet: &v1.HTTPGetAction{
-				Port:   intstr.FromInt(9200),
-				Path:   clusterHealthURL,
-				Scheme: scheme,
+			TCPSocket: &v1.TCPSocketAction{
+				Port: intstr.FromInt(9300),
 			},
 		},
 	}


### PR DESCRIPTION
This will resolve https://github.com/upmc-enterprises/elasticsearch-operator/issues/248.

This operator depends on use of the searchguard-ssl plugin for TLS encryption. However searchguard-ssl is no longer distributed as a standalone plugin past ES version 6.2.4 - https://docs.search-guard.com/latest/search-guard-versions

it has been rolled into the main searchguard plugin.

In order to support ES versions 6.3+ the full blown searchguard plugin needs to be used.

This requires additional steps such as initializing sgadmin prior to any endpoint on port 9200 being available (including _cluster/health and so on) .

This creates an issue as sgadmin itself will not initialize until the masters can reach quorum. And the masters will never reach quorum as discovery.zen.ping.unicast.hosts: ${DISCOVERY_SERVICE} is pointing to a kubernetes service in which all endpoints are failing due to sgadmin not being initialized.

Ive written a quick patch that changes the healthcheck to a TCP port 9300 check to resolve this.

Im open to feedback for better solutions.