### PR TITLE
Support imagePullPolicy for image dependencies

### DIFF
--- a/example/example-es-cluster-minikube.yaml
+++ b/example/example-es-cluster-minikube.yaml
@@ -5,9 +5,12 @@ metadata:
 spec:
   kibana:
     image: docker.elastic.co/kibana/kibana-oss:6.1.3
+    image-pull-policy: Always
   cerebro:
    image: upmcenterprises/cerebro:0.7.2
+    image-pull-policy: Always
   elastic-search-image: upmcenterprises/docker-elasticsearch-kubernetes:6.1.3_0
+  image-pull-policy: Always
   client-node-replicas: 1
   master-node-replicas: 1
   data-node-replicas: 1

--- a/pkg/apis/elasticsearchoperator/v1/cluster.go
+++ b/pkg/apis/elasticsearchoperator/v1/cluster.go
@@ -83,6 +83,9 @@ type ClusterSpec struct {
 	// ElasticSearchImage specifies the docker image to use (optional)
 	ElasticSearchImage string `json:"elastic-search-image"`
 
+	// ImagePullPolicy specifies the image-pull-policy to use (optional)
+	ImagePullPolicy string `json:"image-pull-policy"`
+
 	// Snapshot defines how snapshots are scheduled
 	Snapshot Snapshot `json:"snapshot"`
 
@@ -209,6 +212,9 @@ type Kibana struct {
 	// Defines the image to use for deploying kibana
 	Image string `json:"image"`
 
+	// ImagePullPolicy specifies the image-pull-policy to use (optional)
+	ImagePullPolicy string `json:"image-pull-policy"`
+
 	// serviceAccount to use when running kibana
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
@@ -217,6 +223,10 @@ type Kibana struct {
 type Cerebro struct {
 	// Defines the image to use for deploying Cerebro
 	Image         string `json:"image"`
+
+	// ImagePullPolicy specifies the image-pull-policy to use (optional)
+	ImagePullPolicy string `json:"image-pull-policy"`
+
 	Configuration string `json:"configuration"`
 
 	// serviceAccount to use when running cerebro

--- a/pkg/k8sutil/deployments.go
+++ b/pkg/k8sutil/deployments.go
@@ -96,7 +96,7 @@ func (k *K8sutil) DeleteDeployment(clusterName, namespace, deploymentType string
 
 // CreateClientDeployment creates the client deployment
 func (k *K8sutil) CreateClientDeployment(baseImage string, replicas *int32, javaOptions string,
-	resources myspec.Resources, imagePullSecrets []myspec.ImagePullSecrets, serviceAccountName, clusterName, statsdEndpoint, networkHost, namespace string, useSSL *bool) error {
+	resources myspec.Resources, imagePullSecrets []myspec.ImagePullSecrets, imagePullPolicy, serviceAccountName, clusterName, statsdEndpoint, networkHost, namespace string, useSSL *bool) error {
 
 	component := fmt.Sprintf("elasticsearch-%s", clusterName)
 	discoveryServiceNameCluster := fmt.Sprintf("%s-%s", discoveryServiceName, clusterName)
@@ -172,7 +172,7 @@ func (k *K8sutil) CreateClientDeployment(baseImage string, replicas *int32, java
 									},
 								},
 								Image:           baseImage,
-								ImagePullPolicy: "Always",
+								ImagePullPolicy: v1.PullPolicy(imagePullPolicy),
 								Env: []v1.EnvVar{
 									v1.EnvVar{
 										Name: "NAMESPACE",
@@ -341,7 +341,7 @@ func (k *K8sutil) CreateClientDeployment(baseImage string, replicas *int32, java
 }
 
 // CreateKibanaDeployment creates a deployment of Kibana
-func (k *K8sutil) CreateKibanaDeployment(baseImage, clusterName, namespace string, imagePullSecrets []myspec.ImagePullSecrets, serviceAccountName string, useSSL *bool) error {
+func (k *K8sutil) CreateKibanaDeployment(baseImage, clusterName, namespace string, imagePullSecrets []myspec.ImagePullSecrets, imagePullPolicy string, serviceAccountName string, useSSL *bool) error {
 
 	replicaCount := int32(1)
 
@@ -397,7 +397,7 @@ func (k *K8sutil) CreateKibanaDeployment(baseImage, clusterName, namespace strin
 							v1.Container{
 								Name:            deploymentName,
 								Image:           baseImage,
-								ImagePullPolicy: "Always",
+								ImagePullPolicy: v1.PullPolicy(imagePullPolicy),
 								Env: []v1.EnvVar{
 									v1.EnvVar{
 										Name:  "ELASTICSEARCH_URL",
@@ -484,7 +484,7 @@ func (k *K8sutil) CreateKibanaDeployment(baseImage, clusterName, namespace strin
 }
 
 // CreateCerebroDeployment creates a deployment of Cerebro
-func (k *K8sutil) CreateCerebroDeployment(baseImage, clusterName, namespace, cert string, imagePullSecrets []myspec.ImagePullSecrets, serviceAccountName string, useSSL *bool) error {
+func (k *K8sutil) CreateCerebroDeployment(baseImage, clusterName, namespace, cert string, imagePullSecrets []myspec.ImagePullSecrets, imagePullPolicy string, serviceAccountName string, useSSL *bool) error {
 	replicaCount := int32(1)
 	component := fmt.Sprintf("elasticsearch-%s", clusterName)
 	deploymentName := fmt.Sprintf("%s-%s", cerebroDeploymentName, clusterName)
@@ -530,7 +530,7 @@ func (k *K8sutil) CreateCerebroDeployment(baseImage, clusterName, namespace, cer
 							{
 								Name:            deploymentName,
 								Image:           baseImage,
-								ImagePullPolicy: "Always",
+								ImagePullPolicy: v1.PullPolicy(imagePullPolicy),
 								Command: []string{
 									"bin/cerebro",
 									"-Dconfig.file=/usr/local/cerebro/cfg/application.conf",

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -396,7 +396,7 @@ func processDeploymentType(deploymentType string, clusterName string) (string, s
 }
 
 func buildStatefulSet(statefulSetName, clusterName, deploymentType, baseImage, storageClass, dataDiskSize, javaOptions, serviceAccountName,
-	statsdEndpoint, networkHost string, replicas *int32, useSSL *bool, resources myspec.Resources, imagePullSecrets []myspec.ImagePullSecrets) *apps.StatefulSet {
+	statsdEndpoint, networkHost string, replicas *int32, useSSL *bool, resources myspec.Resources, imagePullSecrets []myspec.ImagePullSecrets, imagePullPolicy string) *apps.StatefulSet {
 
 	_, role, isNodeMaster, isNodeData := processDeploymentType(deploymentType, clusterName)
 
@@ -505,7 +505,7 @@ func buildStatefulSet(statefulSetName, clusterName, deploymentType, baseImage, s
 								},
 							},
 							Image:           baseImage,
-							ImagePullPolicy: "Always",
+							ImagePullPolicy: v1.PullPolicy(imagePullPolicy),
 							Env: []v1.EnvVar{
 								v1.EnvVar{
 									Name: "NAMESPACE",
@@ -653,7 +653,7 @@ func buildStatefulSet(statefulSetName, clusterName, deploymentType, baseImage, s
 
 // CreateDataNodeDeployment creates the data node deployment
 func (k *K8sutil) CreateDataNodeDeployment(deploymentType string, replicas *int32, baseImage, storageClass string, dataDiskSize string, resources myspec.Resources,
-	imagePullSecrets []myspec.ImagePullSecrets, serviceAccountName, clusterName, statsdEndpoint, networkHost, namespace, javaOptions string, useSSL *bool, esUrl string) error {
+	imagePullSecrets []myspec.ImagePullSecrets, imagePullPolicy, serviceAccountName, clusterName, statsdEndpoint, networkHost, namespace, javaOptions string, useSSL *bool, esUrl string) error {
 
 	deploymentName, _, _, _ := processDeploymentType(deploymentType, clusterName)
 
@@ -667,7 +667,7 @@ func (k *K8sutil) CreateDataNodeDeployment(deploymentType string, replicas *int3
 		logrus.Infof("StatefulSet %s not found, creating...", statefulSetName)
 
 		statefulSet := buildStatefulSet(statefulSetName, clusterName, deploymentType, baseImage, storageClass, dataDiskSize, javaOptions, serviceAccountName,
-			statsdEndpoint, networkHost, replicas, useSSL, resources, imagePullSecrets)
+			statsdEndpoint, networkHost, replicas, useSSL, resources, imagePullSecrets, imagePullPolicy)
 
 		if _, err := k.Kclient.AppsV1beta2().StatefulSets(namespace).Create(statefulSet); err != nil {
 			logrus.Error("Could not create stateful set: ", err)

--- a/pkg/k8sutil/k8sutil_test.go
+++ b/pkg/k8sutil/k8sutil_test.go
@@ -40,7 +40,7 @@ func TestSSLCertConfig(t *testing.T) {
 	clusterName := "test"
 	useSSL := false
 	statefulSet := buildStatefulSet("test", clusterName, "master", "foo/image", "test", "1G", "",
-		"", "", "", nil, &useSSL, resources, nil)
+		"", "", "", nil, &useSSL, resources, nil, "")
 
 	for _, volume := range statefulSet.Spec.Template.Spec.Volumes {
 		if volume.Name == fmt.Sprintf("%s-%s", secretName, clusterName) {
@@ -50,7 +50,7 @@ func TestSSLCertConfig(t *testing.T) {
 
 	useSSL = true
 	statefulSet = buildStatefulSet("test", clusterName, "master", "foo/image", "test", "1G", "",
-		"", "", "", nil, &useSSL, resources, nil)
+		"", "", "", nil, &useSSL, resources, nil, "")
 
 	found := false
 	for _, volume := range statefulSet.Spec.Template.Spec.Volumes {

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -211,10 +211,12 @@ func (p *Processor) refreshClusters() error {
 					},
 					Kibana: myspec.Kibana{
 						Image:              cluster.Spec.Kibana.Image,
+						ImagePullPolicy:    cluster.Spec.Kibana.ImagePullPolicy,
 						ServiceAccountName: cluster.Spec.Kibana.ServiceAccountName,
 					},
 					Cerebro: myspec.Cerebro{
 						Image:              cluster.Spec.Cerebro.Image,
+						ImagePullPolicy:    cluster.Spec.Cerebro.ImagePullPolicy,
 						ServiceAccountName: cluster.Spec.Cerebro.ServiceAccountName,
 					},
 					UseSSL:             &useSSL,
@@ -364,7 +366,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 	}
 
 	if err := p.k8sclient.CreateClientDeployment(baseImage, &c.Spec.ClientNodeReplicas, c.Spec.JavaOptions,
-		c.Spec.Resources, c.Spec.ImagePullSecrets, c.Spec.ServiceAccountName, c.ObjectMeta.Name, c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost, c.ObjectMeta.Namespace, c.Spec.UseSSL); err != nil {
+		c.Spec.Resources, c.Spec.ImagePullSecrets, c.Spec.ImagePullPolicy, c.Spec.ServiceAccountName, c.ObjectMeta.Name, c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost, c.ObjectMeta.Namespace, c.Spec.UseSSL); err != nil {
 		logrus.Error("Error creating client deployment ", err)
 		return err
 	}
@@ -387,7 +389,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 		// Create Master Nodes
 		for index, count := range zoneDistributionMaster {
 			if err := p.k8sclient.CreateDataNodeDeployment("master", &count, baseImage, c.Spec.Zones[index], c.Spec.DataDiskSize, c.Spec.Resources,
-				c.Spec.ImagePullSecrets, c.Spec.ServiceAccountName, c.ObjectMeta.Name, c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost,
+				c.Spec.ImagePullSecrets, c.Spec.ImagePullPolicy, c.Spec.ServiceAccountName, c.ObjectMeta.Name, c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost,
 				c.ObjectMeta.Namespace, c.Spec.JavaOptions, c.Spec.UseSSL, c.Spec.Scheduler.ElasticURL); err != nil {
 				logrus.Error("Error creating master node deployment ", err)
 				return err
@@ -397,7 +399,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 		// Create Data Nodes
 		for index, count := range zoneDistributionData {
 			if err := p.k8sclient.CreateDataNodeDeployment("data", &count, baseImage, c.Spec.Zones[index], c.Spec.DataDiskSize, c.Spec.Resources,
-				c.Spec.ImagePullSecrets, c.Spec.ServiceAccountName, c.ObjectMeta.Name, c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost,
+				c.Spec.ImagePullSecrets, c.Spec.ImagePullPolicy, c.Spec.ServiceAccountName, c.ObjectMeta.Name, c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost,
 				c.ObjectMeta.Namespace, c.Spec.JavaOptions, c.Spec.UseSSL, c.Spec.Scheduler.ElasticURL); err != nil {
 				logrus.Error("Error creating data node deployment ", err)
 
@@ -413,7 +415,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 
 		// Create Master Nodes
 		if err := p.k8sclient.CreateDataNodeDeployment("master", func() *int32 { i := int32(c.Spec.MasterNodeReplicas); return &i }(), baseImage, c.Spec.Storage.StorageClass,
-			c.Spec.DataDiskSize, c.Spec.Resources, c.Spec.ImagePullSecrets, c.Spec.ServiceAccountName, c.ObjectMeta.Name,
+			c.Spec.DataDiskSize, c.Spec.Resources, c.Spec.ImagePullSecrets, c.Spec.ImagePullPolicy, c.Spec.ServiceAccountName, c.ObjectMeta.Name,
 			c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost, c.ObjectMeta.Namespace, c.Spec.JavaOptions, c.Spec.UseSSL, c.Spec.Scheduler.ElasticURL); err != nil {
 			logrus.Error("Error creating master node deployment ", err)
 
@@ -422,7 +424,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 
 		// Create Data Nodes
 		if err := p.k8sclient.CreateDataNodeDeployment("data", func() *int32 { i := int32(c.Spec.DataNodeReplicas); return &i }(), baseImage, c.Spec.Storage.StorageClass,
-			c.Spec.DataDiskSize, c.Spec.Resources, c.Spec.ImagePullSecrets, c.Spec.ServiceAccountName, c.ObjectMeta.Name,
+			c.Spec.DataDiskSize, c.Spec.Resources, c.Spec.ImagePullSecrets, c.Spec.ImagePullPolicy, c.Spec.ServiceAccountName, c.ObjectMeta.Name,
 			c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost, c.ObjectMeta.Namespace, c.Spec.JavaOptions, c.Spec.UseSSL, c.Spec.Scheduler.ElasticURL); err != nil {
 			logrus.Error("Error creating data node deployment ", err)
 			return err
@@ -432,7 +434,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 	// Deploy Kibana
 	if c.Spec.Kibana.Image != "" {
 
-		if err := p.k8sclient.CreateKibanaDeployment(c.Spec.Kibana.Image, c.ObjectMeta.Name, c.ObjectMeta.Namespace, c.Spec.ImagePullSecrets, c.Spec.Kibana.ServiceAccountName, c.Spec.UseSSL); err != nil {
+		if err := p.k8sclient.CreateKibanaDeployment(c.Spec.Kibana.Image, c.ObjectMeta.Name, c.ObjectMeta.Namespace, c.Spec.ImagePullSecrets, c.Spec.Kibana.ImagePullPolicy, c.Spec.Kibana.ServiceAccountName, c.Spec.UseSSL); err != nil {
 			logrus.Error("Error creating kibana deployment ", err)
 			return err
 		}
@@ -462,7 +464,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 			}
 		}
 
-		if err := p.k8sclient.CreateCerebroDeployment(c.Spec.Cerebro.Image, c.ObjectMeta.Name, c.ObjectMeta.Namespace, name, c.Spec.ImagePullSecrets, c.Spec.Cerebro.ServiceAccountName, c.Spec.UseSSL); err != nil {
+		if err := p.k8sclient.CreateCerebroDeployment(c.Spec.Cerebro.Image, c.ObjectMeta.Name, c.ObjectMeta.Namespace, name, c.Spec.ImagePullSecrets, c.Spec.Cerebro.ImagePullPolicy, c.Spec.Cerebro.ServiceAccountName, c.Spec.UseSSL); err != nil {
 			logrus.Error("Error creating cerebro deployment ", err)
 			return err
 		}


### PR DESCRIPTION
Adds support for specifying an optional `image-pull-policy` for each image in the cluster spec (ES/Kibana and Cerebro).

I've updated the minikube example to show how this works.

Validation looks to be handled by the underlying k8s core API (via `PullPolicy`)