### PR TITLE
correct spacing on minikube manifest

### DIFF
--- a/example/example-es-cluster-minikube.yaml
+++ b/example/example-es-cluster-minikube.yaml
@@ -7,7 +7,7 @@ spec:
     image: docker.elastic.co/kibana/kibana-oss:6.1.3
     image-pull-policy: Always
   cerebro:
-   image: upmcenterprises/cerebro:0.7.2
+    image: upmcenterprises/cerebro:0.7.2
     image-pull-policy: Always
   elastic-search-image: upmcenterprises/docker-elasticsearch-kubernetes:6.1.3_0
   image-pull-policy: Always


### PR DESCRIPTION
Was testing out the minikube deployment and couldn't apply the raw file with:
```
❯ kubectl create -f https://raw.githubusercontent.com/upmc-enterprises/elasticsearch-operator/master/example/example-es-cluster-minikube.yaml

error: error converting YAML to JSON: yaml: line 10: mapping values are not allowed in this context
```

Just a minor correction on the yaml.