### PR TITLE
Allow encryption as a configurable for storageclass creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Following parameters are available to customize the elastic cluster:
   - Using a provisioner
     - type: Defines the type of storage to provision based upon cloud (e.g. `gp2`)
     - storage-class-provisioner: Defines which type of provisioner to use (e.g. `kubernetes.io/aws-ebs`)
+    - encrypted: Whether or not to use encryption. `"true"` or `"false"` Defaults to: `"true"`
   - Using an existing Storage Class (e.g. storage class for GlusterFS)
     - storage-class: Name of an existing StorageClass object to use (zones can be [])
   - Using a custom Storage Class per zone

--- a/pkg/apis/elasticsearchoperator/v1/cluster.go
+++ b/pkg/apis/elasticsearchoperator/v1/cluster.go
@@ -185,6 +185,9 @@ type Storage struct {
 
 	// Volume Reclaim Policy on Persistent Volumes
 	VolumeReclaimPolicy string `json:"volume-reclaim-policy"`
+
+	// Encrypted chooses whether or not to use encryption ("true or false")
+	Encrypted string `json:"encrypted,omitempty"`
 }
 
 // Resources defines CPU / Memory restrictions on pods
@@ -222,7 +225,7 @@ type Kibana struct {
 // Cerebro properties if wanting operator to deploy for user
 type Cerebro struct {
 	// Defines the image to use for deploying Cerebro
-	Image         string `json:"image"`
+	Image string `json:"image"`
 
 	// ImagePullPolicy specifies the image-pull-policy to use (optional)
 	ImagePullPolicy string `json:"image-pull-policy"`

--- a/pkg/k8sutil/storage.go
+++ b/pkg/k8sutil/storage.go
@@ -33,11 +33,16 @@ import (
 
 // CreateStorageClass creates a storage class
 // NOTE: Right now only creating AWS EBS volumes type gp2
-func (k *K8sutil) CreateStorageClass(zone, storageClassProvisioner, storageType string, clusterName string) error {
+func (k *K8sutil) CreateStorageClass(zone, storageClassProvisioner, storageType string, clusterName string, useEncryption string) error {
 
 	component := "elasticsearch" + "-" + clusterName
 	// Check if storage class exists
 	storageClass, err := k.Kclient.StorageV1beta1().StorageClasses().Get(zone, metav1.GetOptions{})
+
+	// Default encryption to true
+	if useEncryption == "" {
+		useEncryption = "true"
+	}
 
 	if len(storageClass.Name) == 0 {
 		logrus.Infof("StorageClass %s not found, creating...", zone)
@@ -52,7 +57,8 @@ func (k *K8sutil) CreateStorageClass(zone, storageClassProvisioner, storageType 
 			},
 			Provisioner: storageClassProvisioner,
 			Parameters: map[string]string{
-				"type": storageType,
+				"type":      storageType,
+				"encrypted": useEncryption,
 			},
 		}
 

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -377,7 +377,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 
 		// Create Storage Classes
 		for _, sc := range c.Spec.Zones {
-			if err := p.k8sclient.CreateStorageClass(sc, c.Spec.Storage.StorageClassProvisoner, c.Spec.Storage.StorageType, c.ObjectMeta.Name); err != nil {
+			if err := p.k8sclient.CreateStorageClass(sc, c.Spec.Storage.StorageClassProvisoner, c.Spec.Storage.StorageType, c.ObjectMeta.Name, c.Spec.Storage.Encrypted); err != nil {
 				logrus.Error("Error creating storage class ", err)
 				return err
 			}


### PR DESCRIPTION
Allows "encryption" as a configurable in the clusterspec.yml for storageclass creation (defaults to true)

Eg:
```
  storage:
    type: gp2
    storage-class-provisioner: kubernetes.io/aws-ebs
    encrypted: "true"
```