### PR TITLE
allow java-options to be set seperately for client,data,master nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Following parameters are available to customize the elastic cluster:
 - elastic-search-image: Override the elasticsearch image (e.g. `upmcenterprises/docker-elasticsearch-kubernetes:6.1.3_0`)
 - keep-secrets-on-delete (Boolean): Tells the operator to not delete cert secrets when a cluster is deleted
 - use-ssl: Use SSL for communication with the cluster and inside the cluster. Default value is true.
+- java-options: sets java-options for all nodes
+- master-java-options: sets java-options for Master nodes (overrides java-options)
+- client-java-options: sets java-options for Client nodes (overrides java-options)
+- data-java-options: sets java-options for Data nodes (overrides java-options)
+
 - [snapshot](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html)
   - scheduler-enabled: If the cron scheduler should be running to enable snapshotting
   - bucket-name: Name of S3 bucket to dump snapshots

--- a/pkg/apis/elasticsearchoperator/v1/cluster.go
+++ b/pkg/apis/elasticsearchoperator/v1/cluster.go
@@ -92,8 +92,17 @@ type ClusterSpec struct {
 	// Storage defines how volumes are provisioned
 	Storage Storage `json:"storage"`
 
-	// JavaOptions defines args passed to elastic nodes
+	// JavaOptions defines args passed to all elastic nodes
 	JavaOptions string `json:"java-options"`
+
+	// ClientJavaOptions defines args passed to client nodes (Overrides JavaOptions)
+	ClientJavaOptions string `json:"client-java-options"`
+
+	// DataJavaOptions defines args passed to data nodes (Overrides JavaOptions)
+	DataJavaOptions string `json:"data-java-options"`
+
+	// MasterJavaOptions defines args passed to master nodes (Overrides JavaOptions)
+	MasterJavaOptions string `json:"master-java-options"`
 
 	// ImagePullSecrets defines credentials to pull image from private repository (optional)
 	ImagePullSecrets []ImagePullSecrets `json:"image-pull-secrets"`

--- a/pkg/k8sutil/k8sutil_test.go
+++ b/pkg/k8sutil/k8sutil_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/upmc-enterprises/elasticsearch-operator/pkg/apis/elasticsearchoperator/v1"
+	v1 "github.com/upmc-enterprises/elasticsearch-operator/pkg/apis/elasticsearchoperator/v1"
 )
 
 func TestGetESURL(t *testing.T) {
@@ -40,7 +40,7 @@ func TestSSLCertConfig(t *testing.T) {
 	clusterName := "test"
 	useSSL := false
 	statefulSet := buildStatefulSet("test", clusterName, "master", "foo/image", "test", "1G", "",
-		"", "", "", nil, &useSSL, resources, nil, "")
+		"", "", "", "", "", nil, &useSSL, resources, nil, "")
 
 	for _, volume := range statefulSet.Spec.Template.Spec.Volumes {
 		if volume.Name == fmt.Sprintf("%s-%s", secretName, clusterName) {
@@ -50,7 +50,7 @@ func TestSSLCertConfig(t *testing.T) {
 
 	useSSL = true
 	statefulSet = buildStatefulSet("test", clusterName, "master", "foo/image", "test", "1G", "",
-		"", "", "", nil, &useSSL, resources, nil, "")
+		"", "", "", "", "", nil, &useSSL, resources, nil, "")
 
 	found := false
 	for _, volume := range statefulSet.Spec.Template.Spec.Volumes {

--- a/pkg/k8sutil/services.go
+++ b/pkg/k8sutil/services.go
@@ -28,7 +28,7 @@ import (
 	"fmt"
 
 	"github.com/Sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -228,12 +228,12 @@ func (k *K8sutil) CreateMgmtService(service string, clusterName, namespace strin
 		}
 
 		if _, err := k.Kclient.CoreV1().Services(namespace).Create(svc); err != nil {
-			logrus.Error("Could not create service %v ! ", serviceName, err)
+			logrus.Errorf("Could not create service %v %v! ", serviceName, err)
 			return err
 		}
 
 	} else if err != nil {
-		logrus.Error("Could not get service %v! ", serviceName, err)
+		logrus.Errorf("Could not get service %v %v! ", serviceName, err)
 		return err
 	}
 	return nil

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -35,7 +35,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	myspec "github.com/upmc-enterprises/elasticsearch-operator/pkg/apis/elasticsearchoperator/v1"
 	"github.com/upmc-enterprises/elasticsearch-operator/pkg/k8sutil"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -162,6 +162,9 @@ func (p *Processor) refreshClusters() error {
 					Zones:               cluster.Spec.Zones,
 					DataDiskSize:        cluster.Spec.DataDiskSize,
 					JavaOptions:         cluster.Spec.JavaOptions,
+					ClientJavaOptions:   cluster.Spec.ClientJavaOptions,
+					DataJavaOptions:     cluster.Spec.DataJavaOptions,
+					MasterJavaOptions:   cluster.Spec.MasterJavaOptions,
 					NetworkHost:         cluster.Spec.NetworkHost,
 					KeepSecretsOnDelete: cluster.Spec.KeepSecretsOnDelete,
 					Snapshot: myspec.Snapshot{
@@ -365,7 +368,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 		return err
 	}
 
-	if err := p.k8sclient.CreateClientDeployment(baseImage, &c.Spec.ClientNodeReplicas, c.Spec.JavaOptions,
+	if err := p.k8sclient.CreateClientDeployment(baseImage, &c.Spec.ClientNodeReplicas, c.Spec.JavaOptions, c.Spec.ClientJavaOptions,
 		c.Spec.Resources, c.Spec.ImagePullSecrets, c.Spec.ImagePullPolicy, c.Spec.ServiceAccountName, c.ObjectMeta.Name, c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost, c.ObjectMeta.Namespace, c.Spec.UseSSL); err != nil {
 		logrus.Error("Error creating client deployment ", err)
 		return err
@@ -390,7 +393,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 		for index, count := range zoneDistributionMaster {
 			if err := p.k8sclient.CreateDataNodeDeployment("master", &count, baseImage, c.Spec.Zones[index], c.Spec.DataDiskSize, c.Spec.Resources,
 				c.Spec.ImagePullSecrets, c.Spec.ImagePullPolicy, c.Spec.ServiceAccountName, c.ObjectMeta.Name, c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost,
-				c.ObjectMeta.Namespace, c.Spec.JavaOptions, c.Spec.UseSSL, c.Spec.Scheduler.ElasticURL); err != nil {
+				c.ObjectMeta.Namespace, c.Spec.JavaOptions, c.Spec.MasterJavaOptions, c.Spec.DataJavaOptions, c.Spec.UseSSL, c.Spec.Scheduler.ElasticURL); err != nil {
 				logrus.Error("Error creating master node deployment ", err)
 				return err
 			}
@@ -400,7 +403,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 		for index, count := range zoneDistributionData {
 			if err := p.k8sclient.CreateDataNodeDeployment("data", &count, baseImage, c.Spec.Zones[index], c.Spec.DataDiskSize, c.Spec.Resources,
 				c.Spec.ImagePullSecrets, c.Spec.ImagePullPolicy, c.Spec.ServiceAccountName, c.ObjectMeta.Name, c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost,
-				c.ObjectMeta.Namespace, c.Spec.JavaOptions, c.Spec.UseSSL, c.Spec.Scheduler.ElasticURL); err != nil {
+				c.ObjectMeta.Namespace, c.Spec.JavaOptions, c.Spec.MasterJavaOptions, c.Spec.DataJavaOptions, c.Spec.UseSSL, c.Spec.Scheduler.ElasticURL); err != nil {
 				logrus.Error("Error creating data node deployment ", err)
 
 				return err
@@ -416,7 +419,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 		// Create Master Nodes
 		if err := p.k8sclient.CreateDataNodeDeployment("master", func() *int32 { i := int32(c.Spec.MasterNodeReplicas); return &i }(), baseImage, c.Spec.Storage.StorageClass,
 			c.Spec.DataDiskSize, c.Spec.Resources, c.Spec.ImagePullSecrets, c.Spec.ImagePullPolicy, c.Spec.ServiceAccountName, c.ObjectMeta.Name,
-			c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost, c.ObjectMeta.Namespace, c.Spec.JavaOptions, c.Spec.UseSSL, c.Spec.Scheduler.ElasticURL); err != nil {
+			c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost, c.ObjectMeta.Namespace, c.Spec.JavaOptions, c.Spec.MasterJavaOptions, c.Spec.DataJavaOptions, c.Spec.UseSSL, c.Spec.Scheduler.ElasticURL); err != nil {
 			logrus.Error("Error creating master node deployment ", err)
 
 			return err
@@ -425,7 +428,7 @@ func (p *Processor) processElasticSearchCluster(c *myspec.ElasticsearchCluster) 
 		// Create Data Nodes
 		if err := p.k8sclient.CreateDataNodeDeployment("data", func() *int32 { i := int32(c.Spec.DataNodeReplicas); return &i }(), baseImage, c.Spec.Storage.StorageClass,
 			c.Spec.DataDiskSize, c.Spec.Resources, c.Spec.ImagePullSecrets, c.Spec.ImagePullPolicy, c.Spec.ServiceAccountName, c.ObjectMeta.Name,
-			c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost, c.ObjectMeta.Namespace, c.Spec.JavaOptions, c.Spec.UseSSL, c.Spec.Scheduler.ElasticURL); err != nil {
+			c.Spec.Instrumentation.StatsdHost, c.Spec.NetworkHost, c.ObjectMeta.Namespace, c.Spec.JavaOptions, c.Spec.MasterJavaOptions, c.Spec.DataJavaOptions, c.Spec.UseSSL, c.Spec.Scheduler.ElasticURL); err != nil {
 			logrus.Error("Error creating data node deployment ", err)
 			return err
 		}


### PR DESCRIPTION
Fixes: https://github.com/upmc-enterprises/elasticsearch-operator/issues/273

Allows different java-options per node type: Client, Master, Data

```
client-java-options: "-Xms1024m -Xmx1024m"
master-java-options: "-Xms2048m -Xmx2048m"
data-java-options: "-Xms4096m -Xmx4096m"
```

if one or more are not defined then the existing `java-options` value will be used