### PR TITLE
add component name lenght check

### DIFF
--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -282,6 +282,9 @@ func (p *Processor) processPodEvent(c *v1.Pod) error {
 func (p *Processor) processDataPodEvent(c *v1.Pod) error {
 	// Set the policy to retain
 	name := c.Labels["component"]
+	if len(name) <= 14 {
+		return nil
+	}
 	name = name[14:len(name)]
 
 	p.k8sclient.UpdateVolumeReclaimPolicy(p.clusters[fmt.Sprintf("%s-%s", name, c.ObjectMeta.Namespace)].ESCluster.Spec.Storage.VolumeReclaimPolicy, c.ObjectMeta.Namespace, name)
@@ -291,6 +294,9 @@ func (p *Processor) processDataPodEvent(c *v1.Pod) error {
 
 func (p *Processor) processMasterPodEvent(c *v1.Pod) error {
 	name := c.Labels["component"]
+	if len(name) <= 14 {
+		return nil
+	}
 	name = name[14:len(name)]
 	// get all ready master nodes
 	m, err := p.k8sclient.GetMasterNodes(c.ObjectMeta.Namespace, name)


### PR DESCRIPTION
We have met a problem in our env that we do have an pod who has role=data and component=abc labels, so this will case the operator panic:

```
panic: runtime error: slice bounds out of range

goroutine 84 [running]:
github.com/upmc-enterprises/elasticsearch-operator/pkg/processor.(*Processor).processDataPodEvent(0xc000384480, 0xc000b69748, 0x10b0148, 0x4)
        /home/steve/godev/src/github.com/upmc-enterprises/elasticsearch-operator/pkg/processor/processor.go:285 +0x205
github.com/upmc-enterprises/elasticsearch-operator/pkg/processor.(*Processor).processPodEvent(0xc000384480, 0xc000b69748, 0x0, 0x0)
        /home/steve/godev/src/github.com/upmc-enterprises/elasticsearch-operator/pkg/processor/processor.go:275 +0x137
github.com/upmc-enterprises/elasticsearch-operator/pkg/processor.(*Processor).WatchDataPodEvents.func1(0xc000100120, 0xc000384480, 0xc000360300, 0xc0000e0840, 0xc0003bc160)
        /home/steve/godev/src/github.com/upmc-enterprises/elasticsearch-operator/pkg/processor/processor.go:109 +0x1ed
created by github.com/upmc-enterprises/elasticsearch-operator/pkg/processor.(*Processor).WatchDataPodEvents
        /home/steve/godev/src/github.com/upmc-enterprises/elasticsearch-operator/pkg/processor/processor.go:105 +0x78
```
`processDataPodEvent` does not check component length so cause panic. This PR will fix the problem.

```go
func (p *Processor) processDataPodEvent(c *v1.Pod) error {
	// Set the policy to retain
	name := c.Labels["component"]
	name = name[14:len(name)]

	p.k8sclient.UpdateVolumeReclaimPolicy(p.clusters[fmt.Sprintf("%s-%s", name, c.ObjectMeta.Namespace)].ESCluster.Spec.Storage.VolumeReclaimPolicy, c.ObjectMeta.Namespace, name)

	return nil
}
```