### PR TITLE
Add 'devpreq' action to Makefile to setup local machine to run operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,8 @@ helm-package:
 
 test: clean
 	go test $$(go list ./... | grep -v /vendor/)
+
+devpreq:
+	mkdir -p /tmp/certs/config && mkdir -p /tmp/certs/certs
+	go get -u github.com/cloudflare/cfssl/cmd/cfssl
+	go get -u github.com/cloudflare/cfssl/cmd/cfssljson


### PR DESCRIPTION
Signed-off-by: Steve Sloka <slokas@vmware.com>