### PR TITLE
Replaced daemonset with initContainers

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -61,7 +61,7 @@ func init() {
 	flag.StringVar(&baseImage, "baseImage", "upmcenterprises/docker-elasticsearch-kubernetes:6.1.3_0", "Base image to use when spinning up the elasticsearch components.")
 	flag.StringVar(&kubeCfgFile, "kubecfg-file", "", "Location of kubecfg file for access to kubernetes master service; --kube_master_url overrides the URL part of this; if neither this nor --kube_master_url are provided, defaults to service account tokens")
 	flag.StringVar(&masterHost, "masterhost", "http://127.0.0.1:8001", "Full url to k8s api server")
-	flag.BoolVar(&enableInitDaemonset, "enableInitDaemonset", true, "Set to false to disable the sysctl init daemonset")
+	flag.BoolVar(&enableInitDaemonset, "enableInitDaemonset", false, "Set to false to disable the sysctl init daemonset")
 	flag.StringVar(&initDaemonsetNamespace, "initDaemonsetNamespace", "default", "Namespace to deploy the sysctl init daemonset into")
 	flag.StringVar(&busyboxImage, "busybox-image", "busybox:1.26.2", "Image to use for sysctl init daemonset")
 	flag.Parse()

--- a/pkg/k8sutil/deployments.go
+++ b/pkg/k8sutil/deployments.go
@@ -174,6 +174,16 @@ func (k *K8sutil) CreateClientDeployment(baseImage string, replicas *int32, java
 						Containers: []v1.Container{
 							v1.Container{
 								Name: deploymentName,
+								InitContainers: []v1.Container{
+		                            {
+		                                Name:  "sysctl",
+		                                Image: "busybox",
+		                                Command: []string{ "sysctl", "-w", "vm.max_map_count=262144"},
+		                                SecurityContext: &v1.SecurityContext{
+		                                    Privileged: &[]bool{true}[0],
+		                                },
+		                            },
+		                        },
 								SecurityContext: &v1.SecurityContext{
 									Privileged: &[]bool{true}[0],
 									Capabilities: &v1.Capabilities{

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -506,7 +506,18 @@ func buildStatefulSet(statefulSetName, clusterName, deploymentType, baseImage, s
 									},
 								},
 							},
-						}},
+						},
+					},
+					InitContainers: []v1.Container{
+                        {
+                            Name:  "sysctl",
+                            Image: "busybox",
+                            Command: []string{ "sysctl", "-w", "vm.max_map_count=262144"},
+                            SecurityContext: &v1.SecurityContext{
+                                Privileged: &[]bool{true}[0],
+                            },
+                        },
+                    },
 					Containers: []v1.Container{
 						v1.Container{
 							Name: statefulSetName,


### PR DESCRIPTION
Using deamonset for setting the sysctl parameter "**vm.max_map_count**" spins up a pod in every node in the cluster, which might become an issue in large clusters. Also, the pods will use up a not-so-insignificant amount of IP space of the cluster. A better alternative is to use initContainers to set the kernel parameter to the required value so that unnecessary pods are not created in the cluster.