### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ Both operator and cluster can be deployed using Helm charts:
 
 ```sh
 $ helm repo add es-operator https://raw.githubusercontent.com/upmc-enterprises/elasticsearch-operator/master/charts/
-$ helm install --name elasticsearch-operator es-operator/elasticsearch-operator --set rbac.enabled=True --namespace logging
-$ helm install --name=elasticsearch es-operator/elasticsearch --set kibana.enabled=True --set cerebro.enabled=True --set zones="{eu-west-1a,eu-west-1b}" --namespace logging
+$ helm install elasticsearch-operator es-operator/elasticsearch-operator --set rbac.enabled=True --namespace logging
+$ helm install elasticsearch es-operator/elasticsearch --set kibana.enabled=True --set cerebro.enabled=True --set zones="{eu-west-1a,eu-west-1b}" --namespace logging
 ⚡ $helm list
 NAME      	              REVISION	UPDATED                 	STATUS  	CHART                       	NAMESPACE
 elasticsearch	            1       	Thu Dec  7 11:53:45 2017	DEPLOYED	elasticsearch-0.1.0         	default


### PR DESCRIPTION
As of Helm v3,  the release name is now mandatory as part of the command and therefore the '--name' flag is neither needed nor recognised.